### PR TITLE
Use querystring in get helper

### DIFF
--- a/lib/request.mjs
+++ b/lib/request.mjs
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import querystring from 'querystring';
 import getLogger from './logger.mjs';
 
 const logger = getLogger('lib/request');
@@ -22,8 +23,10 @@ export const post = (uri, payload, config = {}) => {
   return axios.post(uri, payload, config).then(logAndReturn);
 };
 
-export const get = (uri, queryString, config = {}) => {
+export const get = (uri, queryObject, config = {}) => {
+  const queryString = querystring.stringify(queryObject);
   logger.verbose('Sending a GET request to %s', uri);
   logger.verbose('QueryString:', queryString);
+
   return axios.get(`${uri}?${queryString}`, config).then(logAndReturn);
 };

--- a/lib/shopify.mjs
+++ b/lib/shopify.mjs
@@ -51,7 +51,7 @@ const getCustomerByEmail = email => {
   const endpoint = `/admin/customers/search.json`;
   const uri = getShopifyEndpoint(endpoint);
 
-  return get(uri, `query=${email}`);
+  return get(uri, { query: email });
 };
 
 const sendPost = (endpoint, payload) => {


### PR DESCRIPTION
Fix #5 using [querystring](https://nodejs.org/api/querystring.html) from Node available APIs instead of using external libs in order to avoid bloating the dependencies.