### PR TITLE
Upgrade node runtime to 10.x

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,7 +19,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
   iamRoleStatements:
     - Effect: 'Allow'
       Action:


### PR DESCRIPTION
Node 8.10 is EOL. Amazon recently sent out an email encouraging customers to upgrade.

<img width="780" alt="Screenshot 2019-10-21 at 17 57 29" src="https://user-images.githubusercontent.com/886567/67216806-76c6f700-f42c-11e9-9aac-03af54424fb2.png">
